### PR TITLE
Correct driver name lookup

### DIFF
--- a/src/DoctrineSupportServiceProvider.php
+++ b/src/DoctrineSupportServiceProvider.php
@@ -44,7 +44,7 @@ class DoctrineSupportServiceProvider extends ServiceProvider
      */
     protected function addDoctrineTypes(Connection $connection)
     {
-        $name = $connection->getName();
+        $name = $connection->getDriverName();
 
         foreach (array_get($this->types, $name, []) as $type => $handler) {
             if (!Type::hasType($type)) {


### PR DESCRIPTION
The code here has been using the connection name rather than the driver name to determine whether to attach this functionality. This was causing issues when you had something like the below in `database.php`:
```
    'connections' => [
        'master' => [
            'driver' => 'mysql',
            'host' => 'master_database',
            .... etc
        ],
        'slave' => [
            'driver' => 'mysql',
            'host' => 'master_database',
            .... etc
        ],
    ],
```
The proposed change fixes this by looking at the driver name (mysql in both) rather than the connection name (master/slave depending on connection).